### PR TITLE
Adding a reboot annotation

### DIFF
--- a/prometheus/node-exporter-full.json
+++ b/prometheus/node-exporter-full.json
@@ -62,6 +62,16 @@
           "type": "dashboard"
         },
         "type": "dashboard"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "enable": true,
+        "expr": "changes(node_boot_time_seconds{instance=\"$node\"})",
+        "iconColor": "red",
+        "name": "Reboot"
       }
     ]
   },


### PR DESCRIPTION
Adding a reboot annotation for a easier overview of when a server was rebooted.
![image](https://user-images.githubusercontent.com/7606777/209957174-7e0d1b52-2bd9-4bee-8b25-7535f525393e.png)
