### PR TITLE
Use codespell to fix all the typos

### DIFF
--- a/prometheus/bind9-full.json
+++ b/prometheus/bind9-full.json
@@ -541,7 +541,7 @@
           "refId": "A"
         }
       ],
-      "title": "Incomming Requests",
+      "title": "Incoming Requests",
       "type": "timeseries"
     },
     {
@@ -1856,7 +1856,7 @@
               },
               "expr": "sum by (instance, view)(irate(bind_resolver_dnssec_validation_success_total{instance=~\"$host:$port\",view=~\"$view\"}[5m]))",
               "interval": "",
-              "legendFormat": "Sucess {{ view }}",
+              "legendFormat": "Success {{ view }}",
               "refId": "A"
             }
           ],

--- a/prometheus/haproxy-2-full.json
+++ b/prometheus/haproxy-2-full.json
@@ -13130,7 +13130,7 @@
               "expr": "haproxy_process_max_sockets{instance=\"$host\"}",
               "interval": "$interval",
               "intervalFactor": 1,
-              "legendFormat": "Maximum numer of open sockets",
+              "legendFormat": "Maximum number of open sockets",
               "metric": "",
               "refId": "B",
               "step": 240

--- a/prometheus/node-exporter-full.json
+++ b/prometheus/node-exporter-full.json
@@ -1729,7 +1729,7 @@
           {
             "matcher": {
               "id": "byName",
-              "options": "Avaliable"
+              "options": "Available"
             },
             "properties": [
               {
@@ -5289,7 +5289,7 @@
               "step": 240
             }
           ],
-          "title": "Memory Commited",
+          "title": "Memory Committed",
           "type": "timeseries"
         },
         {
@@ -6478,7 +6478,7 @@
               "expr": "node_memory_Mapped_bytes{instance=\"$node\",job=\"$job\"}",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "Mapped - Used memory in mapped pages files which have been mmaped, such as libraries",
+              "legendFormat": "Mapped - Used memory in mapped pages files which have been mapped, such as libraries",
               "refId": "A",
               "step": 240
             },
@@ -6516,7 +6516,7 @@
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "ShmemPmdMapped - Ammount of shared (shmem/tmpfs) memory backed by huge pages",
+              "legendFormat": "ShmemPmdMapped - Amount of shared (shmem/tmpfs) memory backed by huge pages",
               "refId": "D",
               "step": 240
             }
@@ -7290,7 +7290,7 @@
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
-              "legendFormat": "VmallocChunk - Largest contigious block of vmalloc area which is free",
+              "legendFormat": "VmallocChunk - Largest contiguous block of vmalloc area which is free",
               "refId": "A",
               "step": 240
             },
@@ -10381,7 +10381,7 @@
               "expr": "node_memory_NFS_Unstable_bytes{instance=\"$node\",job=\"$job\"}",
               "format": "time_series",
               "intervalFactor": 1,
-              "legendFormat": "NFS Unstable - Memory in NFS pages sent to the server, but not yet commited to the storage",
+              "legendFormat": "NFS Unstable - Memory in NFS pages sent to the server, but not yet committed to the storage",
               "refId": "A",
               "step": 240
             }
@@ -11631,7 +11631,7 @@
               "step": 240
             }
           ],
-          "title": "Time Syncronized Drift",
+          "title": "Time Synchronized Drift",
           "type": "timeseries"
         },
         {
@@ -11866,7 +11866,7 @@
               "step": 240
             }
           ],
-          "title": "Time Syncronized Status",
+          "title": "Time Synchronized Status",
           "type": "timeseries"
         },
         {
@@ -20784,7 +20784,7 @@
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "TCP_tw - Sockets wating close",
+              "legendFormat": "TCP_tw - Sockets waiting close",
               "refId": "E",
               "step": 240
             }
@@ -21311,7 +21311,7 @@
               "custom": {
                 "axisCenteredZero": false,
                 "axisColorMode": "text",
-                "axisLabel": "octects out (-) / in (+)",
+                "axisLabel": "octets out (-) / in (+)",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
                 "drawStyle": "line",
@@ -22497,7 +22497,7 @@
               "hide": false,
               "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "MaxConn - Limit on the total number of TCP connections the entity can support (Dinamic is \"-1\")",
+              "legendFormat": "MaxConn - Limit on the total number of TCP connections the entity can support (Dynamic is \"-1\")",
               "refId": "B",
               "step": 240
             }


### PR DESCRIPTION
Supersedes https://github.com/rfmoz/grafana-dashboards/pull/103

Used https://github.com/codespell-project/codespell

```sh
pip install codespell
```