### PR TITLE
Remove useless ':' in 'Host:'

### DIFF
--- a/prometheus/node-exporter-full.json
+++ b/prometheus/node-exporter-full.json
@@ -23290,7 +23290,7 @@
         "definition": "label_values(node_uname_info{job=\"$job\"}, instance)",
         "hide": 0,
         "includeAll": false,
-        "label": "Host:",
+        "label": "Host",
         "multi": false,
         "name": "node",
         "options": [],


### PR DESCRIPTION
The ':' is useless and inconsistent with the format of other selection boxes.