### PR TITLE
Add Frequency scaling and PSI panels

### DIFF
--- a/prometheus/node-exporter-full.json
+++ b/prometheus/node-exporter-full.json
@@ -2656,7 +2656,7 @@
             "h": 12,
             "w": 12,
             "x": 0,
-            "y": 7
+            "y": 23
           },
           "id": 3,
           "links": [],
@@ -3163,7 +3163,7 @@
             "h": 12,
             "w": 12,
             "x": 12,
-            "y": 7
+            "y": 23
           },
           "id": 24,
           "links": [],
@@ -3442,7 +3442,7 @@
             "h": 12,
             "w": 12,
             "x": 0,
-            "y": 19
+            "y": 35
           },
           "id": 84,
           "links": [],
@@ -3557,7 +3557,7 @@
             "h": 12,
             "w": 12,
             "x": 12,
-            "y": 19
+            "y": 35
           },
           "id": 156,
           "links": [],
@@ -3987,7 +3987,7 @@
             "h": 12,
             "w": 12,
             "x": 0,
-            "y": 31
+            "y": 47
           },
           "id": 229,
           "links": [],
@@ -4214,7 +4214,7 @@
             "h": 12,
             "w": 12,
             "x": 12,
-            "y": 31
+            "y": 47
           },
           "id": 42,
           "links": [],
@@ -4359,7 +4359,7 @@
             "h": 12,
             "w": 12,
             "x": 0,
-            "y": 43
+            "y": 59
           },
           "id": 127,
           "links": [],
@@ -4493,7 +4493,7 @@
             "h": 12,
             "w": 12,
             "x": 12,
-            "y": 43
+            "y": 59
           },
           "id": 319,
           "options": {
@@ -4888,7 +4888,7 @@
             "h": 10,
             "w": 12,
             "x": 0,
-            "y": 38
+            "y": 54
           },
           "id": 136,
           "links": [],
@@ -5278,7 +5278,7 @@
             "h": 10,
             "w": 12,
             "x": 12,
-            "y": 38
+            "y": 54
           },
           "id": 135,
           "links": [],
@@ -5649,7 +5649,7 @@
             "h": 10,
             "w": 12,
             "x": 0,
-            "y": 48
+            "y": 64
           },
           "id": 191,
           "links": [],
@@ -6078,7 +6078,7 @@
             "h": 10,
             "w": 12,
             "x": 12,
-            "y": 48
+            "y": 64
           },
           "id": 130,
           "links": [],
@@ -6484,7 +6484,7 @@
             "h": 10,
             "w": 12,
             "x": 0,
-            "y": 58
+            "y": 74
           },
           "id": 138,
           "links": [],
@@ -6911,7 +6911,7 @@
             "h": 10,
             "w": 12,
             "x": 12,
-            "y": 58
+            "y": 74
           },
           "id": 131,
           "links": [],
@@ -7296,7 +7296,7 @@
             "h": 10,
             "w": 12,
             "x": 0,
-            "y": 68
+            "y": 84
           },
           "id": 70,
           "links": [],
@@ -7681,7 +7681,7 @@
             "h": 10,
             "w": 12,
             "x": 12,
-            "y": 68
+            "y": 84
           },
           "id": 159,
           "links": [],
@@ -8067,7 +8067,7 @@
             "h": 10,
             "w": 12,
             "x": 0,
-            "y": 78
+            "y": 94
           },
           "id": 129,
           "links": [],
@@ -8437,7 +8437,7 @@
             "h": 10,
             "w": 12,
             "x": 12,
-            "y": 78
+            "y": 94
           },
           "id": 160,
           "links": [],
@@ -8824,7 +8824,7 @@
             "h": 10,
             "w": 12,
             "x": 0,
-            "y": 88
+            "y": 104
           },
           "id": 140,
           "links": [],
@@ -9220,7 +9220,7 @@
             "h": 10,
             "w": 12,
             "x": 12,
-            "y": 88
+            "y": 104
           },
           "id": 71,
           "links": [],
@@ -9604,7 +9604,7 @@
             "h": 10,
             "w": 12,
             "x": 0,
-            "y": 98
+            "y": 114
           },
           "id": 128,
           "links": [],
@@ -9987,7 +9987,7 @@
             "h": 10,
             "w": 12,
             "x": 12,
-            "y": 98
+            "y": 114
           },
           "id": 137,
           "links": [],
@@ -10388,7 +10388,7 @@
             "h": 10,
             "w": 12,
             "x": 0,
-            "y": 108
+            "y": 124
           },
           "id": 132,
           "links": [],
@@ -10529,7 +10529,7 @@
             "h": 10,
             "w": 12,
             "x": 0,
-            "y": 25
+            "y": 41
           },
           "id": 176,
           "links": [],
@@ -10655,7 +10655,7 @@
             "h": 10,
             "w": 12,
             "x": 12,
-            "y": 25
+            "y": 41
           },
           "id": 22,
           "links": [],
@@ -11044,7 +11044,7 @@
             "h": 10,
             "w": 12,
             "x": 0,
-            "y": 35
+            "y": 51
           },
           "id": 175,
           "links": [],
@@ -11457,7 +11457,7 @@
             "h": 10,
             "w": 12,
             "x": 12,
-            "y": 35
+            "y": 51
           },
           "id": 307,
           "links": [],
@@ -11603,7 +11603,7 @@
             "h": 10,
             "w": 12,
             "x": 0,
-            "y": 40
+            "y": 56
           },
           "id": 260,
           "links": [],
@@ -11735,7 +11735,7 @@
             "h": 10,
             "w": 12,
             "x": 12,
-            "y": 40
+            "y": 56
           },
           "id": 291,
           "links": [],
@@ -11854,7 +11854,7 @@
             "h": 10,
             "w": 12,
             "x": 0,
-            "y": 50
+            "y": 66
           },
           "id": 168,
           "links": [],
@@ -11970,7 +11970,7 @@
             "h": 10,
             "w": 12,
             "x": 12,
-            "y": 50
+            "y": 66
           },
           "id": 294,
           "links": [],
@@ -12113,7 +12113,7 @@
             "h": 10,
             "w": 12,
             "x": 0,
-            "y": 27
+            "y": 43
           },
           "id": 62,
           "links": [],
@@ -12227,7 +12227,7 @@
             "h": 10,
             "w": 12,
             "x": 12,
-            "y": 27
+            "y": 43
           },
           "id": 315,
           "links": [],
@@ -12330,7 +12330,7 @@
             "h": 10,
             "w": 12,
             "x": 0,
-            "y": 37
+            "y": 53
           },
           "id": 148,
           "links": [],
@@ -12446,7 +12446,7 @@
             "h": 10,
             "w": 12,
             "x": 12,
-            "y": 37
+            "y": 53
           },
           "id": 149,
           "links": [],
@@ -12608,7 +12608,7 @@
             "h": 10,
             "w": 12,
             "x": 0,
-            "y": 47
+            "y": 63
           },
           "id": 313,
           "links": [],
@@ -12736,7 +12736,7 @@
             "h": 10,
             "w": 12,
             "x": 12,
-            "y": 47
+            "y": 63
           },
           "id": 305,
           "links": [],
@@ -12872,7 +12872,7 @@
             "h": 10,
             "w": 12,
             "x": 12,
-            "y": 57
+            "y": 73
           },
           "id": 314,
           "links": [],
@@ -13015,7 +13015,7 @@
             "h": 10,
             "w": 12,
             "x": 0,
-            "y": 42
+            "y": 26
           },
           "id": 8,
           "links": [],
@@ -13130,7 +13130,7 @@
             "h": 10,
             "w": 12,
             "x": 12,
-            "y": 42
+            "y": 26
           },
           "id": 7,
           "links": [],
@@ -13191,6 +13191,449 @@
             }
           ],
           "title": "System Load",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "links": [],
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "hertz"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Max"
+                },
+                "properties": [
+                  {
+                    "id": "custom.lineStyle",
+                    "value": {
+                      "dash": [
+                        10,
+                        10
+                      ],
+                      "fill": "dash"
+                    }
+                  },
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "blue",
+                      "mode": "fixed"
+                    }
+                  },
+                  {
+                    "id": "custom.fillOpacity",
+                    "value": 10
+                  },
+                  {
+                    "id": "custom.hideFrom",
+                    "value": {
+                      "legend": true,
+                      "tooltip": false,
+                      "viz": false
+                    }
+                  },
+                  {
+                    "id": "custom.fillBelowTo",
+                    "value": "Min"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Min"
+                },
+                "properties": [
+                  {
+                    "id": "custom.lineStyle",
+                    "value": {
+                      "dash": [
+                        10,
+                        10
+                      ],
+                      "fill": "dash"
+                    }
+                  },
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "blue",
+                      "mode": "fixed"
+                    }
+                  },
+                  {
+                    "id": "custom.hideFrom",
+                    "value": {
+                      "legend": true,
+                      "tooltip": false,
+                      "viz": false
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 0,
+            "y": 36
+          },
+          "id": 321,
+          "links": [],
+          "options": {
+            "legend": {
+              "calcs": [
+                "mean",
+                "lastNotNull",
+                "max",
+                "min"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "pluginVersion": "9.2.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "node_cpu_scaling_frequency_hertz{instance=\"$node\",job=\"$job\"}",
+              "format": "time_series",
+              "hide": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "CPU {{ cpu }}",
+              "range": true,
+              "refId": "B",
+              "step": 240
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "avg(node_cpu_scaling_frequency_max_hertz{instance=\"$node\",job=\"$job\"})",
+              "format": "time_series",
+              "hide": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "Max",
+              "range": true,
+              "refId": "A",
+              "step": 240
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "avg(node_cpu_scaling_frequency_min_hertz{instance=\"$node\",job=\"$job\"})",
+              "format": "time_series",
+              "hide": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "Min",
+              "range": true,
+              "refId": "C",
+              "step": 240
+            }
+          ],
+          "title": "CPU Frequency Scaling",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "description": "https://docs.kernel.org/accounting/psi.html",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "decimals": 1,
+              "links": [],
+              "mappings": [],
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Memory some"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "dark-red",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Memory full"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "light-red",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "I/O some"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "dark-blue",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "I/O full"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "light-blue",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 12,
+            "x": 12,
+            "y": 36
+          },
+          "id": 322,
+          "links": [],
+          "options": {
+            "legend": {
+              "calcs": [
+                "mean",
+                "lastNotNull",
+                "max",
+                "min"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "9.2.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "rate(node_pressure_cpu_waiting_seconds_total{instance=\"$node\",job=\"$job\"}[$__rate_interval])",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "CPU some",
+              "range": true,
+              "refId": "CPU some",
+              "step": 240
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "rate(node_pressure_memory_waiting_seconds_total{instance=\"$node\",job=\"$job\"}[$__rate_interval])",
+              "format": "time_series",
+              "hide": false,
+              "intervalFactor": 1,
+              "legendFormat": "Memory some",
+              "range": true,
+              "refId": "Memory some",
+              "step": 240
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "rate(node_pressure_memory_stalled_seconds_total{instance=\"$node\",job=\"$job\"}[$__rate_interval])",
+              "format": "time_series",
+              "hide": false,
+              "intervalFactor": 1,
+              "legendFormat": "Memory full",
+              "range": true,
+              "refId": "Memory full",
+              "step": 240
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "rate(node_pressure_io_waiting_seconds_total{instance=\"$node\",job=\"$job\"}[$__rate_interval])",
+              "format": "time_series",
+              "hide": false,
+              "intervalFactor": 1,
+              "legendFormat": "I/O some",
+              "range": true,
+              "refId": "I/O some",
+              "step": 240
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "editorMode": "code",
+              "expr": "rate(node_pressure_io_stalled_seconds_total{instance=\"$node\",job=\"$job\"}[$__rate_interval])",
+              "format": "time_series",
+              "hide": false,
+              "intervalFactor": 1,
+              "legendFormat": "I/O full",
+              "range": true,
+              "refId": "I/O full",
+              "step": 240
+            }
+          ],
+          "title": "Pressure Stall Information",
           "type": "timeseries"
         },
         {
@@ -13295,7 +13738,7 @@
             "h": 10,
             "w": 12,
             "x": 0,
-            "y": 52
+            "y": 46
           },
           "id": 259,
           "links": [],
@@ -13397,7 +13840,7 @@
             "h": 10,
             "w": 12,
             "x": 12,
-            "y": 52
+            "y": 46
           },
           "id": 306,
           "links": [],
@@ -13500,7 +13943,7 @@
             "h": 10,
             "w": 12,
             "x": 0,
-            "y": 62
+            "y": 56
           },
           "id": 151,
           "links": [],
@@ -13601,7 +14044,7 @@
             "h": 10,
             "w": 12,
             "x": 12,
-            "y": 62
+            "y": 56
           },
           "id": 308,
           "links": [],
@@ -13724,7 +14167,7 @@
             "h": 10,
             "w": 12,
             "x": 0,
-            "y": 72
+            "y": 66
           },
           "id": 64,
           "links": [],
@@ -13904,7 +14347,7 @@
             "h": 10,
             "w": 12,
             "x": 0,
-            "y": 43
+            "y": 59
           },
           "id": 158,
           "links": [],
@@ -14081,7 +14524,7 @@
             "h": 10,
             "w": 12,
             "x": 12,
-            "y": 43
+            "y": 59
           },
           "id": 300,
           "links": [],
@@ -14197,7 +14640,7 @@
             "h": 10,
             "w": 12,
             "x": 0,
-            "y": 53
+            "y": 69
           },
           "id": 302,
           "links": [],
@@ -14328,7 +14771,7 @@
             "h": 10,
             "w": 12,
             "x": 0,
-            "y": 30
+            "y": 46
           },
           "id": 297,
           "links": [],
@@ -14506,7 +14949,7 @@
             "h": 10,
             "w": 12,
             "x": 12,
-            "y": 30
+            "y": 46
           },
           "id": 298,
           "links": [],
@@ -15001,7 +15444,7 @@
             "h": 10,
             "w": 12,
             "x": 0,
-            "y": 31
+            "y": 47
           },
           "id": 9,
           "links": [],
@@ -15426,7 +15869,7 @@
             "h": 10,
             "w": 12,
             "x": 12,
-            "y": 31
+            "y": 47
           },
           "id": 33,
           "links": [],
@@ -15853,7 +16296,7 @@
             "h": 10,
             "w": 12,
             "x": 0,
-            "y": 41
+            "y": 57
           },
           "id": 37,
           "links": [],
@@ -16271,7 +16714,7 @@
             "h": 10,
             "w": 12,
             "x": 12,
-            "y": 41
+            "y": 57
           },
           "id": 35,
           "links": [],
@@ -16686,7 +17129,7 @@
             "h": 10,
             "w": 12,
             "x": 0,
-            "y": 51
+            "y": 67
           },
           "id": 133,
           "links": [],
@@ -17100,7 +17543,7 @@
             "h": 10,
             "w": 12,
             "x": 12,
-            "y": 51
+            "y": 67
           },
           "id": 36,
           "links": [],
@@ -17516,7 +17959,7 @@
             "h": 10,
             "w": 12,
             "x": 0,
-            "y": 61
+            "y": 77
           },
           "id": 34,
           "links": [],
@@ -17919,7 +18362,7 @@
             "h": 10,
             "w": 12,
             "x": 12,
-            "y": 61
+            "y": 77
           },
           "id": 301,
           "links": [],
@@ -18061,7 +18504,7 @@
             "h": 10,
             "w": 12,
             "x": 0,
-            "y": 46
+            "y": 62
           },
           "id": 43,
           "links": [],
@@ -18192,7 +18635,7 @@
             "h": 10,
             "w": 12,
             "x": 12,
-            "y": 46
+            "y": 62
           },
           "id": 41,
           "links": [],
@@ -18296,7 +18739,7 @@
             "h": 10,
             "w": 12,
             "x": 0,
-            "y": 56
+            "y": 72
           },
           "id": 28,
           "links": [],
@@ -18411,7 +18854,7 @@
             "h": 10,
             "w": 12,
             "x": 12,
-            "y": 56
+            "y": 72
           },
           "id": 219,
           "links": [],
@@ -18532,7 +18975,7 @@
             "h": 10,
             "w": 12,
             "x": 0,
-            "y": 66
+            "y": 82
           },
           "id": 44,
           "links": [],
@@ -18746,7 +19189,7 @@
             "h": 10,
             "w": 12,
             "x": 0,
-            "y": 31
+            "y": 47
           },
           "id": 60,
           "links": [],
@@ -18875,7 +19318,7 @@
             "h": 10,
             "w": 12,
             "x": 12,
-            "y": 31
+            "y": 47
           },
           "id": 142,
           "links": [],
@@ -19002,7 +19445,7 @@
             "h": 10,
             "w": 12,
             "x": 0,
-            "y": 41
+            "y": 57
           },
           "id": 143,
           "links": [],
@@ -19129,7 +19572,7 @@
             "h": 10,
             "w": 12,
             "x": 12,
-            "y": 41
+            "y": 57
           },
           "id": 141,
           "links": [],
@@ -19256,7 +19699,7 @@
             "h": 10,
             "w": 12,
             "x": 0,
-            "y": 51
+            "y": 67
           },
           "id": 146,
           "links": [],
@@ -19371,7 +19814,7 @@
             "h": 10,
             "w": 12,
             "x": 12,
-            "y": 51
+            "y": 67
           },
           "id": 144,
           "links": [],
@@ -19498,7 +19941,7 @@
             "h": 10,
             "w": 12,
             "x": 0,
-            "y": 61
+            "y": 77
           },
           "id": 145,
           "links": [],
@@ -19601,7 +20044,7 @@
             "h": 10,
             "w": 12,
             "x": 12,
-            "y": 61
+            "y": 77
           },
           "id": 231,
           "links": [],
@@ -19716,7 +20159,7 @@
             "h": 10,
             "w": 12,
             "x": 0,
-            "y": 71
+            "y": 87
           },
           "id": 232,
           "links": [],
@@ -19839,7 +20282,7 @@
             "h": 10,
             "w": 12,
             "x": 12,
-            "y": 71
+            "y": 87
           },
           "id": 61,
           "links": [],
@@ -19953,7 +20396,7 @@
             "h": 10,
             "w": 12,
             "x": 0,
-            "y": 81
+            "y": 97
           },
           "id": 230,
           "links": [],
@@ -20056,7 +20499,7 @@
             "h": 10,
             "w": 12,
             "x": 12,
-            "y": 81
+            "y": 97
           },
           "id": 288,
           "links": [],
@@ -20159,7 +20602,7 @@
             "h": 10,
             "w": 12,
             "x": 0,
-            "y": 91
+            "y": 107
           },
           "id": 280,
           "links": [],
@@ -20262,7 +20705,7 @@
             "h": 10,
             "w": 12,
             "x": 12,
-            "y": 91
+            "y": 107
           },
           "id": 289,
           "links": [],
@@ -20376,7 +20819,7 @@
             "h": 10,
             "w": 12,
             "x": 0,
-            "y": 101
+            "y": 117
           },
           "id": 290,
           "links": [],
@@ -20492,7 +20935,7 @@
             "h": 10,
             "w": 12,
             "x": 12,
-            "y": 101
+            "y": 117
           },
           "id": 310,
           "links": [],
@@ -20595,7 +21038,7 @@
             "h": 10,
             "w": 12,
             "x": 0,
-            "y": 111
+            "y": 127
           },
           "id": 309,
           "links": [],
@@ -20736,7 +21179,7 @@
             "h": 10,
             "w": 12,
             "x": 0,
-            "y": 32
+            "y": 48
           },
           "id": 63,
           "links": [],
@@ -20893,7 +21336,7 @@
             "h": 10,
             "w": 12,
             "x": 12,
-            "y": 32
+            "y": 48
           },
           "id": 124,
           "links": [],
@@ -21023,7 +21466,7 @@
             "h": 10,
             "w": 12,
             "x": 0,
-            "y": 42
+            "y": 58
           },
           "id": 125,
           "links": [],
@@ -21140,7 +21583,7 @@
             "h": 10,
             "w": 12,
             "x": 12,
-            "y": 42
+            "y": 58
           },
           "id": 220,
           "links": [],
@@ -21268,7 +21711,7 @@
             "h": 10,
             "w": 12,
             "x": 0,
-            "y": 52
+            "y": 68
           },
           "id": 126,
           "links": [],
@@ -21411,7 +21854,7 @@
             "h": 10,
             "w": 12,
             "x": 0,
-            "y": 33
+            "y": 49
           },
           "id": 221,
           "links": [],
@@ -21527,7 +21970,7 @@
             "h": 10,
             "w": 12,
             "x": 12,
-            "y": 33
+            "y": 49
           },
           "id": 81,
           "links": [],
@@ -21643,7 +22086,7 @@
             "h": 10,
             "w": 12,
             "x": 0,
-            "y": 43
+            "y": 59
           },
           "id": 115,
           "links": [],
@@ -21771,7 +22214,7 @@
             "h": 10,
             "w": 12,
             "x": 12,
-            "y": 43
+            "y": 59
           },
           "id": 50,
           "links": [],
@@ -21898,7 +22341,7 @@
             "h": 10,
             "w": 12,
             "x": 0,
-            "y": 53
+            "y": 69
           },
           "id": 55,
           "links": [],
@@ -22013,7 +22456,7 @@
             "h": 10,
             "w": 12,
             "x": 12,
-            "y": 53
+            "y": 69
           },
           "id": 109,
           "links": [],
@@ -22189,7 +22632,7 @@
             "h": 10,
             "w": 12,
             "x": 0,
-            "y": 63
+            "y": 79
           },
           "id": 299,
           "links": [],
@@ -22307,7 +22750,7 @@
             "h": 10,
             "w": 12,
             "x": 12,
-            "y": 63
+            "y": 79
           },
           "id": 104,
           "links": [],
@@ -22488,7 +22931,7 @@
             "h": 10,
             "w": 12,
             "x": 0,
-            "y": 73
+            "y": 89
           },
           "id": 85,
           "links": [],
@@ -22619,7 +23062,7 @@
             "h": 10,
             "w": 12,
             "x": 12,
-            "y": 73
+            "y": 89
           },
           "id": 91,
           "links": [],
@@ -22751,7 +23194,7 @@
             "h": 10,
             "w": 12,
             "x": 0,
-            "y": 83
+            "y": 99
           },
           "id": 82,
           "links": [],
@@ -22864,7 +23307,7 @@
             "h": 10,
             "w": 12,
             "x": 12,
-            "y": 83
+            "y": 99
           },
           "id": 320,
           "links": [],
@@ -23044,7 +23487,7 @@
             "h": 10,
             "w": 12,
             "x": 0,
-            "y": 50
+            "y": 66
           },
           "id": 40,
           "links": [],
@@ -23171,7 +23614,7 @@
             "h": 10,
             "w": 12,
             "x": 12,
-            "y": 50
+            "y": 66
           },
           "id": 157,
           "links": [],
@@ -23374,6 +23817,6 @@
   "timezone": "browser",
   "title": "Node Exporter Full",
   "uid": "rYdddlPWk",
-  "version": 86,
+  "version": 87,
   "weekStart": ""
 }

--- a/prometheus/node-exporter-full.json
+++ b/prometheus/node-exporter-full.json
@@ -13449,7 +13449,6 @@
                   "mode": "off"
                 }
               },
-              "decimals": 1,
               "links": [],
               "mappings": [],
               "min": 0,


### PR DESCRIPTION
Add CPU Frequency scaling and Pressure Stall Information panels to System Misc section.

Fixes #111 and #144 

Example for PSI vs load averages for a busy looping machine:
![image](https://github.com/rfmoz/grafana-dashboards/assets/345210/24f60e63-5ab0-4a6b-8ffb-62914fac8991)

Example for Frequency scaling:

![image](https://github.com/rfmoz/grafana-dashboards/assets/345210/fdf30032-2abc-4381-baf7-b10c594f9766)
