### PR TITLE
Fix "Datasource ${DS_PROMETHEUS} was not found" error affecting auto-provisioned `node-exporter-full.json` dashboard

### DIFF
--- a/prometheus/node-exporter-full.json
+++ b/prometheus/node-exporter-full.json
@@ -17216,7 +17216,7 @@
         "current": {},
         "includeAll": false,
         "label": "Datasource",
-        "name": "datasource",
+        "name": "DS_PROMETHEUS",
         "options": [],
         "query": "prometheus",
         "refresh": 1,


### PR DESCRIPTION
It seems like downloading `node-exporter-full.json` and putting it in a provisioning directory for Grafana (tested with 11.6.0-security-01) makes it auto-import the dashboard, but it would report an error:

> Datasource ${DS_PROMETHEUS} was not found

This particular error seems to be experienced frequently (with this and other dashboards). Ref:

- https://github.com/spantaleev/matrix-docker-ansible-deploy/issues/2834
- https://github.com/grafana/grafana/issues/80666

I don't claim to have a full understanding as to what really causes this problem. Perhaps some Grafana bug in newer versions (though I cannot say when exactly it stopped working)? Perhaps the fact that some of us try to import this (or another) dashboard via a provisioning directory?

In any case, it seems like with the patch proposed here, the error doesn't happen anymore.