### PR TITLE
feat(node-full): Improve filesystem usage scale

### DIFF
--- a/prometheus/node-exporter-full.json
+++ b/prometheus/node-exporter-full.json
@@ -1731,7 +1731,6 @@
           },
           "links": [],
           "mappings": [],
-          "max": 100,
           "min": 0,
           "thresholds": {
             "mode": "absolute",
@@ -1753,12 +1752,6 @@
       },
       "id": 152,
       "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
         "tooltip": {
           "hideZeros": false,
           "mode": "multi",


### PR DESCRIPTION
If all filesystems are only say below 20% then it's much more interesting to scale the Y axis to 20% instead of to full 100%.

Also drop completely default legend config for this one.